### PR TITLE
Enable logging for Queue Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Added
+  * [GH-2](https://github.com/claranet/terraform-azurerm-storage-account/pull/2): Enable logging for Queue Services
+
 # v7.0.1 - 2022-10-07
 
 Fixed

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ module "storage_account" {
     module.logs.log_analytics_workspace_id
   ]
 
+  # Set by default
+  queue_properties_logging = {
+    delete                = true
+    read                  = true
+    write                 = true
+    version               = "1.0"
+    retention_policy_days = 10
+  }
+
   containers = [
     {
       name = "bloc1"

--- a/examples/main/modules.tf
+++ b/examples/main/modules.tf
@@ -63,6 +63,15 @@ module "storage_account" {
     module.logs.log_analytics_workspace_id
   ]
 
+  # Set by default
+  queue_properties_logging = {
+    delete                = true
+    read                  = true
+    write                 = true
+    version               = "1.0"
+    retention_policy_days = 10
+  }
+
   containers = [
     {
       name = "bloc1"

--- a/r-storage-account.tf
+++ b/r-storage-account.tf
@@ -74,6 +74,19 @@ resource "azurerm_storage_account" "storage" {
     }
   }
 
+  dynamic "queue_properties" {
+    for_each = var.queue_properties_logging != null ? ["enabled"] : []
+    content {
+      logging {
+        delete                = var.queue_properties_logging.delete
+        read                  = var.queue_properties_logging.read
+        write                 = var.queue_properties_logging.write
+        version               = var.queue_properties_logging.version
+        retention_policy_days = var.queue_properties_logging.retention_policy_days
+      }
+    }
+  }
+
   dynamic "network_rules" {
     for_each = var.nfsv3_enabled ? ["enabled"] : []
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -248,3 +248,15 @@ variable "queues" {
   }))
   default = []
 }
+
+variable "queue_properties_logging" {
+  description = "Logging queue properties"
+  type = object({
+    delete                = optional(bool, true)
+    read                  = optional(bool, true)
+    write                 = optional(bool, true)
+    version               = optional(string, "1.0")
+    retention_policy_days = optional(number, 10)
+  })
+  default = {}
+}


### PR DESCRIPTION
It's recommended to have logging enabled for queue services, even when not used.

It also helps to properly silence static analyzers e.g. tfsec, instead of ignoring it, which's why I'm making this PR.

![Screenshot 2022-10-05 at 17 59 14](https://user-images.githubusercontent.com/22898667/194109664-14e8307d-1f25-4212-af70-ab04c57f0306.png)
