### PR TITLE
explicitly mark storage account properties as sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,7 @@
 output "storage_account_properties" {
   description = "Created Storage Account properties."
   value       = azurerm_storage_account.storage
+  sensitive   = true
 }
 
 output "storage_account_id" {


### PR DESCRIPTION
Fixes #(issue) .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

```
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 1:
│    1: output "storage_account_properties" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
```

## Changes proposed in this pull request

-
-
-

@claranet/fr-azure-reviewers
