### PR TITLE
Ensure storage_ip_rules regexall only matches /31 and /32, but leaves /30 alone since it is valid

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules#ip_rules
   # > Small address ranges using "/31" or "/32" prefix sizes are not supported. These ranges should be configured using individual IP address rules without prefix specified.
-  storage_ip_rules = toset(flatten([for cidr in var.allowed_cidrs : (length(regexall("/3(1|2)", cidr)) > 0 ? [cidrhost(cidr, 0), cidrhost(cidr, -1)] : [cidr])]))
+  storage_ip_rules = toset(flatten([for cidr in var.allowed_cidrs : length(regexall("/3(1|2)", cidr)) > 0 ? [cidrhost(cidr, 0), cidrhost(cidr, -1)] : [cidr]]))
 
   pitr_enabled = (
     alltrue([var.blob_data_protection.change_feed_enabled, var.blob_data_protection.versioning_enabled, var.blob_data_protection.container_point_in_time_restore])

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules#ip_rules
   # > Small address ranges using "/31" or "/32" prefix sizes are not supported. These ranges should be configured using individual IP address rules without prefix specified.
-  storage_ip_rules = toset(flatten([for cidr in var.allowed_cidrs : (length(regexall("/3.", cidr)) > 0 ? [cidrhost(cidr, 0), cidrhost(cidr, -1)] : [cidr])]))
+  storage_ip_rules = toset(flatten([for cidr in var.allowed_cidrs : (length(regexall("/3(1|2)", cidr)) > 0 ? [cidrhost(cidr, 0), cidrhost(cidr, -1)] : [cidr])]))
 
   pitr_enabled = (
     alltrue([var.blob_data_protection.change_feed_enabled, var.blob_data_protection.versioning_enabled, var.blob_data_protection.container_point_in_time_restore])


### PR DESCRIPTION
Fixes #19 

Based on https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#restrictions-for-ip-network-rules and my testing, /30 CIDRs should be allowed and are configurable as storage account firewall rules.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes proposed in this pull request

- Change `regexall("/3.", cidr)` to `regexall("/3(1|2)", cidr)` to ensure /30 CIDRs are passed through correctly.

If I have a data service tag resource as follows:
```
# az network list-service-tags --location usgovvirginia
#
data "azurerm_network_service_tags" "frontdoor" {
  location = var.azure_location
  service  = "AzureFrontDoor"
}
```

And I try configuring this module as follows:
```
  allowed_cidrs = concat(
    ["64.102.0.0/16"],
    data.azurerm_network_service_tags.frontdoor.ipv4_cidrs
  )
```

It will fail to apply the /30 CIDRs from Azure service tags to the storage account.  For example, 20.140.152.52/30 will be changed to 20.140.152.52 and this means 20.140.152.53, 20.140.152.54, 20.140.152.55 will be blocked when they should be allowed.

@claranet/fr-azure-reviewers
